### PR TITLE
Readiness polling APIs

### DIFF
--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -114,13 +114,6 @@ impl TcpStream {
         ConnectFuture { inner: inner }
     }
 
-    /// TODO docs
-    pub fn poll_ready(&self, lw: &LocalWaker, ready: mio::Ready)
-        -> Poll<io::Result<mio::Ready>>
-    {
-        self.io.poll_ready(lw, ready)
-    }
-
     /// Check the TCP stream's read readiness state.
     ///
     /// The mask argument allows specifying what readiness to notify on. This

--- a/src/net/udp/socket.rs
+++ b/src/net/udp/socket.rs
@@ -214,11 +214,6 @@ impl UdpSocket {
         RecvDgram::new(self, buf)
     }
 
-    /// TODO docs
-    pub fn poll_ready(&self, lw: &LocalWaker, ready: mio::Ready) -> Poll<io::Result<mio::Ready>> {
-        self.io.poll_ready(lw, ready)
-    }
-
     /// Check the UDP socket's read readiness state.
     ///
     /// The mask argument allows specifying what readiness to notify on. This

--- a/src/reactor/poll_evented.rs
+++ b/src/reactor/poll_evented.rs
@@ -156,44 +156,6 @@ where E: Evented
         Ok(io)
     }
 
-    /// TODO Docs for poll_ready
-    pub fn poll_ready(&self, lw: &LocalWaker, ready: mio::Ready) -> Poll<io::Result<mio::Ready>>
-    {
-        if ready.is_empty() {
-            return Poll::Ready(Ok(ready))
-        }
-
-        let mut ret = mio::Ready::empty();
-
-        if ready.is_writable() {
-            if let Poll::Ready(v) = self.poll_write_ready(lw)? {
-                ret |= v & ready;
-            }
-        }
-
-        let ready = ready - mio::Ready::writable();
-
-        if !ready.is_empty() {
-            if let Poll::Ready(v) = self.poll_read_ready(lw)? {
-                ret |= v & ready;
-            }
-        }
-
-        if ret.is_empty() {
-            if ready.is_writable() {
-                self.clear_write_ready(lw)?;
-            }
-
-            if ready.is_readable() {
-                self.clear_read_ready(lw)?;
-            }
-
-            Poll::Pending
-        } else {
-            Poll::Ready(Ok(ret))
-        }
-    }
-
     /// Check the I/O resource's read readiness state.
     ///
     /// The mask argument allows specifying what readiness to notify on. This

--- a/src/uds/stream.rs
+++ b/src/uds/stream.rs
@@ -90,11 +90,6 @@ impl UnixStream {
         UnixStream { io }
     }
 
-    /// TODO docs
-    pub fn poll_ready(&self, lw: &LocalWaker, ready: Ready) -> Poll<io::Result<Ready>> {
-        self.io.poll_ready(lw, ready)
-    }
-
     /// Test whether this socket is ready to be read or not.
     pub fn poll_read_ready(&self, lw: &LocalWaker) -> Poll<io::Result<Ready>> {
         self.io.poll_read_ready(lw)


### PR DESCRIPTION
Changes to the APIs for checking readiness:

1. Add `poll_ready` API for checking platform specific readiness. This is based on the original tokio-core API.
2. Normalize some of the lower APIs to standard conventions: use `lw` as localwaker name, make sure localwaker comes before other arguments, etc.
3. Inline the poll_ready macro to make it easier to audit the poll_read_ready and poll_write_ready methods for correctness.