### PR TITLE
Remove the redundant struct Incoming

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -13,12 +13,11 @@ fn main() -> io::Result<()> {
     executor::block_on(async {
         let mut threadpool = ThreadPool::new()?;
 
-        let listener = TcpListener::bind(&"127.0.0.1:7878".parse().unwrap())?;
-        let mut incoming = listener.incoming();
+        let mut listener = TcpListener::bind(&"127.0.0.1:7878".parse().unwrap())?;
 
         println!("Listening on 127.0.0.1:7878");
 
-        while let Some(stream) = await!(incoming.next()) {
+        while let Some(stream) = await!(listener.next()) {
             let stream = stream?;
             let addr = stream.peer_addr()?;
 

--- a/examples/shakespeare.rs
+++ b/examples/shakespeare.rs
@@ -26,12 +26,11 @@ fn main() -> io::Result<()> {
     executor::block_on(async {
         let mut threadpool = ThreadPool::new()?;
 
-        let listener = TcpListener::bind(&"127.0.0.1:7878".parse().unwrap())?;
-        let mut incoming = listener.incoming();
+        let mut listener = TcpListener::bind(&"127.0.0.1:7878".parse().unwrap())?;
 
         println!("Listening on 127.0.0.1:7878");
 
-        while let Some(stream) = await!(incoming.next()) {
+        while let Some(stream) = await!(listener.next()) {
             let stream = stream?;
             let addr = stream.peer_addr()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,10 @@
 //!
 //! async fn listen() -> Result<(), Box<dyn std::error::Error + 'static>> {
 //!     let socket_addr = "127.0.0.1:8080".parse()?;
-//!     let listener = TcpListener::bind(&socket_addr)?;
-//!     let mut incoming = listener.incoming();
+//!     let mut listener = TcpListener::bind(&socket_addr)?;
 //!
 //!     // accept connections and process them serially
-//!     while let Some(stream) = await!(incoming.next()) {
+//!     while let Some(stream) = await!(listener.next()) {
 //!         await!(say_hello(stream?));
 //!     }
 //!     Ok(())

--- a/src/tcp/mod.rs
+++ b/src/tcp/mod.rs
@@ -29,11 +29,10 @@
 //!
 //! async fn listen() -> Result<(), Box<dyn std::error::Error + 'static>> {
 //!     let socket_addr = "127.0.0.1:80".parse()?;
-//!     let listener = TcpListener::bind(&socket_addr)?;
-//!     let mut incoming = listener.incoming();
+//!     let mut listener = TcpListener::bind(&socket_addr)?;
 //!
 //!     // accept connections and process them serially
-//!     while let Some(stream) = await!(incoming.next()) {
+//!     while let Some(stream) = await!(listener.next()) {
 //!         await!(say_hello(stream?));
 //!     }
 //!     Ok(())
@@ -43,5 +42,5 @@
 mod listener;
 mod stream;
 
-pub use self::listener::{Incoming, TcpListener};
+pub use self::listener::{TcpListener};
 pub use self::stream::{ConnectFuture, TcpStream};

--- a/src/uds/mod.rs
+++ b/src/uds/mod.rs
@@ -12,11 +12,10 @@
 //! }
 //!
 //! async fn listen() -> Result<(), Box<dyn std::error::Error + 'static>> {
-//!     let listener = UnixListener::bind("/tmp/sock")?;
-//!     let mut incoming = listener.incoming();
+//!     let mut listener = UnixListener::bind("/tmp/sock")?;
 //!
 //!     // accept connections and process them serially
-//!     while let Some(stream) = await!(incoming.next()) {
+//!     while let Some(stream) = await!(listener.next()) {
 //!         await!(say_hello(stream?));
 //!     }
 //!     Ok(())
@@ -29,6 +28,6 @@ mod stream;
 mod ucred;
 
 pub use self::datagram::UnixDatagram;
-pub use self::listener::{Incoming, UnixListener};
+pub use self::listener::{UnixListener};
 pub use self::stream::{ConnectFuture, UnixStream};
 pub use self::ucred::UCred;

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -21,7 +21,7 @@ const THE_WINTERS_TALE: &[u8] = b"
 #[test]
 fn listener_reads() {
     drop(env_logger::try_init());
-    let server = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let mut server = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let addr = server.local_addr().unwrap();
 
     // client thread
@@ -32,8 +32,7 @@ fn listener_reads() {
 
     executor::block_on(async {
         let mut buf = vec![0; THE_WINTERS_TALE.len()];
-        let mut incoming = server.incoming();
-        let mut stream = await!(incoming.next()).unwrap().unwrap();
+        let mut stream = await!(server.next()).unwrap().unwrap();
         await!(stream.read_exact(&mut buf)).unwrap();
         assert_eq!(buf, THE_WINTERS_TALE);
     });
@@ -42,7 +41,7 @@ fn listener_reads() {
 #[test]
 fn listener_writes() {
     drop(env_logger::try_init());
-    let server = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let mut server = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let addr = server.local_addr().unwrap();
 
     // client thread
@@ -54,8 +53,7 @@ fn listener_writes() {
     });
 
     executor::block_on(async {
-        let mut incoming = server.incoming();
-        let mut stream = await!(incoming.next()).unwrap().unwrap();
+        let mut stream = await!(server.next()).unwrap().unwrap();
         await!(stream.write_all(THE_WINTERS_TALE)).unwrap();
     });
 }
@@ -63,7 +61,7 @@ fn listener_writes() {
 #[test]
 fn both_sides_async_using_threadpool() {
     drop(env_logger::try_init());
-    let server = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+    let mut server = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let addr = server.local_addr().unwrap();
     
     let mut pool = executor::ThreadPool::new().unwrap();
@@ -75,8 +73,7 @@ fn both_sides_async_using_threadpool() {
 
     pool.run(FutureObj::from(Box::pinned(async {
         let mut buf = vec![0; THE_WINTERS_TALE.len()];
-        let mut incoming = server.incoming();
-        let mut stream = await!(incoming.next()).unwrap().unwrap();
+        let mut stream = await!(server.next()).unwrap().unwrap();
         await!(stream.read_exact(&mut buf)).unwrap();
         assert_eq!(buf, THE_WINTERS_TALE);
     })));

--- a/tests/uds.rs
+++ b/tests/uds.rs
@@ -27,7 +27,7 @@ fn listener_reads() -> Result<(), Error> {
     let tmp_dir = TempDir::new("listener_reads")?;
     let file_path = tmp_dir.path().join("sock");
 
-    let listener = UnixListener::bind(&file_path)?;
+    let mut listener = UnixListener::bind(&file_path)?;
     let file_path = listener.local_addr()?;
 
     // client thread
@@ -39,8 +39,7 @@ fn listener_reads() -> Result<(), Error> {
 
     executor::block_on(async {
         let mut buf = vec![0; THE_WINTERS_TALE.len()];
-        let mut incoming = listener.incoming();
-        let mut stream = await!(incoming.next()).unwrap().unwrap();
+        let mut stream = await!(listener.next()).unwrap().unwrap();
         await!(stream.read_exact(&mut buf)).unwrap();
         assert_eq!(buf, THE_WINTERS_TALE);
     });
@@ -54,7 +53,7 @@ fn listener_writes() -> Result<(), Error> {
     let tmp_dir = TempDir::new("listener_writes")?;
     let file_path = tmp_dir.path().join("sock");
 
-    let listener = UnixListener::bind(&file_path)?;
+    let mut listener = UnixListener::bind(&file_path)?;
     let file_path = listener.local_addr()?;
 
     // client thread
@@ -67,8 +66,7 @@ fn listener_writes() -> Result<(), Error> {
     });
 
     executor::block_on(async {
-        let mut incoming = listener.incoming();
-        let mut stream = await!(incoming.next()).unwrap().unwrap();
+        let mut stream = await!(listener.next()).unwrap().unwrap();
         await!(stream.write_all(THE_WINTERS_TALE)).unwrap();
     });
 
@@ -81,7 +79,7 @@ fn both_sides_async_using_threadpool() -> Result<(), Error>{
     let tmp_dir = TempDir::new("listener_writes")?;
     let file_path = tmp_dir.path().join("sock");
 
-    let listener = UnixListener::bind(&file_path)?;
+    let mut listener = UnixListener::bind(&file_path)?;
     let file_path = listener.local_addr()?;
 
     let mut pool = executor::ThreadPool::new().unwrap();
@@ -94,8 +92,7 @@ fn both_sides_async_using_threadpool() -> Result<(), Error>{
 
     pool.run(FutureObj::from(Box::pinned(async {
         let mut buf = vec![0; THE_WINTERS_TALE.len()];
-        let mut incoming = listener.incoming();
-        let mut stream = await!(incoming.next()).unwrap().unwrap();
+        let mut stream = await!(listener.next()).unwrap().unwrap();
         await!(stream.read_exact(&mut buf)).unwrap();
         assert_eq!(buf, THE_WINTERS_TALE);
     })));


### PR DESCRIPTION
`Incoming` is just a proxy for `*Listener`, complicating the public API without adding any real value.

Even in Tokio, it doesn't seem to add any value. Probably still around for backwards compatibility?

Edit: Re-added the docs from `TcpListener::incoming`. Happy to move the docs around to wherever you feel is most appropriate.