### PR TITLE
Update futures dependency to 0.3.0-alpha.11 (#54)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ slab = "0.4.0"
 libc = "0.2.43"
 
 [dependencies.futures]
-version = "0.3.0-alpha.10"
+version = "0.3.0-alpha.11"
 package = "futures-preview"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //! }
 //! ```
 
-#![feature(futures_api, pin, arbitrary_self_types)]
+#![feature(futures_api, arbitrary_self_types)]
 #![deny(missing_docs, missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
pin is stable since 1.33.0