### PR TITLE
Move poll_evented into the raw module for #52

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,8 @@ pub use async_ready;
 #[cfg(unix)]
 pub mod uds;
 
+pub mod raw;
+
 mod reactor;
 
 #[doc(inline)]

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -1,0 +1,5 @@
+//! Raw poll APIs
+//!
+//! This module exposes raw Poll APIs.
+
+pub mod poll_evented;

--- a/src/raw/mod.rs
+++ b/src/raw/mod.rs
@@ -2,4 +2,5 @@
 //!
 //! This module exposes raw Poll APIs.
 
-pub mod poll_evented;
+mod poll_evented;
+pub use poll_evented::*;

--- a/src/raw/poll_evented.rs
+++ b/src/raw/poll_evented.rs
@@ -1,4 +1,7 @@
-use super::Registration;
+//! Polling API bindings
+
+use crate::reactor::platform;
+use crate::reactor::registration::Registration;
 
 use futures::io::{AsyncRead, AsyncWrite};
 use futures::task::Waker;
@@ -165,7 +168,7 @@ where
 
         // Load cached & encoded readiness.
         let mut cached = self.inner.read_readiness.load(Relaxed);
-        let mask = mio::Ready::readable() | super::platform::hup();
+        let mask = mio::Ready::readable() | platform::hup();
 
         // See if the current readiness matches any bits.
         let mut ret = mio::Ready::from_usize(cached) & mio::Ready::readable();
@@ -244,7 +247,7 @@ where
 
         // Load cached & encoded readiness.
         let mut cached = self.inner.write_readiness.load(Relaxed);
-        let mask = mio::Ready::writable() | super::platform::hup();
+        let mask = mio::Ready::writable() | platform::hup();
 
         // See if the current readiness matches any bits.
         let mut ret = mio::Ready::from_usize(cached) & mio::Ready::writable();

--- a/src/reactor/mod.rs
+++ b/src/reactor/mod.rs
@@ -1,13 +1,11 @@
 pub(crate) mod background;
-mod poll_evented;
-mod registration;
+pub(crate) mod registration;
 mod sharded_rwlock;
 
 // ===== Public re-exports =====
 
 use self::background::Background;
-pub use self::poll_evented::PollEvented;
-use self::registration::Registration;
+pub use crate::raw::poll_evented::PollEvented;
 
 // ===== Private imports =====
 
@@ -551,7 +549,7 @@ impl Direction {
 }
 
 #[cfg(unix)]
-mod platform {
+pub(crate) mod platform {
     use mio::unix::UnixReady;
     use mio::Ready;
 
@@ -565,7 +563,7 @@ mod platform {
 }
 
 #[cfg(windows)]
-mod platform {
+pub(crate) mod platform {
     use mio::Ready;
 
     pub fn hup() -> Ready {

--- a/src/reactor/mod.rs
+++ b/src/reactor/mod.rs
@@ -5,7 +5,7 @@ mod sharded_rwlock;
 // ===== Public re-exports =====
 
 use self::background::Background;
-pub use crate::raw::poll_evented::PollEvented;
+pub use crate::raw::PollEvented;
 
 // ===== Private imports =====
 

--- a/src/reactor/registration.rs
+++ b/src/reactor/registration.rs
@@ -41,7 +41,7 @@ use std::{io, ptr, usize};
 /// [`poll_read_ready`]: #method.poll_read_ready`]
 /// [`poll_write_ready`]: #method.poll_write_ready`]
 #[derive(Debug)]
-pub struct Registration {
+pub(crate) struct Registration {
     /// Stores the handle. Once set, the value is not changed.
     ///
     /// Setting this requires acquiring the lock from state.

--- a/src/tcp/listener.rs
+++ b/src/tcp/listener.rs
@@ -11,7 +11,7 @@ use futures::task::Waker;
 use futures::{ready, Poll};
 use mio;
 
-use crate::reactor::PollEvented;
+use crate::raw::PollEvented;
 
 /// A TCP socket server, listening for connections.
 ///

--- a/src/tcp/stream.rs
+++ b/src/tcp/stream.rs
@@ -12,7 +12,7 @@ use futures::{ready, Future, Poll};
 use iovec::IoVec;
 use mio;
 
-use crate::reactor::PollEvented;
+use crate::raw::PollEvented;
 
 /// A TCP stream between a local and a remote socket.
 ///
@@ -604,8 +604,8 @@ impl Future for ConnectFuture {
 
                 Poll::Ready(Ok(stream))
             }
-            ConnectFutureState::Error(e)        => Poll::Ready(Err(e)),
-            ConnectFutureState::Empty           => panic!("can't poll TCP stream twice"),
+            ConnectFutureState::Error(e) => Poll::Ready(Err(e)),
+            ConnectFutureState::Empty => panic!("can't poll TCP stream twice"),
         }
     }
 }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -23,7 +23,7 @@ use futures::Future;
 use futures::{ready, Poll};
 use mio;
 
-use crate::reactor::PollEvented;
+use crate::raw::PollEvented;
 
 /// A UDP socket.
 pub struct UdpSocket {
@@ -107,7 +107,11 @@ impl UdpSocket {
     /// # }
     /// ```
     pub fn send_to<'a, 'b>(&'a mut self, buf: &'b [u8], target: &'b SocketAddr) -> SendTo<'a, 'b> {
-        SendTo { buf, target, socket: self }
+        SendTo {
+            buf,
+            target,
+            socket: self,
+        }
     }
 
     /// Receives data from the socket. On success, returns the number of bytes
@@ -401,7 +405,11 @@ impl<'a, 'b> Future for SendTo<'a, 'b> {
     type Output = io::Result<usize>;
 
     fn poll(mut self: Pin<&mut Self>, waker: &Waker) -> Poll<Self::Output> {
-        let SendTo { socket, buf, target } = &mut *self;
+        let SendTo {
+            socket,
+            buf,
+            target,
+        } = &mut *self;
         socket.poll_send_to(waker, buf, target)
     }
 }

--- a/src/uds/datagram.rs
+++ b/src/uds/datagram.rs
@@ -1,4 +1,4 @@
-use crate::reactor::PollEvented;
+use crate::raw::PollEvented;
 
 use async_datagram::AsyncDatagram;
 use async_ready::{AsyncReadReady, AsyncWriteReady, TakeError};

--- a/src/uds/listener.rs
+++ b/src/uds/listener.rs
@@ -1,6 +1,6 @@
 use super::UnixStream;
 
-use crate::reactor::PollEvented;
+use crate::raw::PollEvented;
 
 use async_ready::{AsyncReady, TakeError};
 use futures::task::Waker;

--- a/src/uds/stream.rs
+++ b/src/uds/stream.rs
@@ -1,6 +1,6 @@
 use super::ucred::{self, UCred};
 
-use crate::reactor::PollEvented;
+use crate::raw::PollEvented;
 
 use async_ready::{AsyncReadReady, AsyncWriteReady, TakeError};
 use futures::io::{AsyncRead, AsyncWrite};


### PR DESCRIPTION
Moves `poll_evented` into the raw module as discussed in #52 .

The documentation for the `poll_evented` module itself could be better, therefore, please let me know how to improve it 😄 .  Running clippy and rustfmt resulted in changes across many different modules not related to these changes, so that could be a separate PR probably.