### PR TITLE
add support for Read + Write for TcpStream and UnixStream

### DIFF
--- a/src/tcp/stream.rs
+++ b/src/tcp/stream.rs
@@ -525,6 +525,21 @@ impl AsyncWriteReady for TcpStream {
     }
 }
 
+impl io::Read for TcpStream {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
+        self.io.get_mut().read(buf)
+    }
+}
+
+impl io::Write for TcpStream {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
+        self.io.get_mut().write(buf)
+    }
+    fn flush(&mut self) -> Result<(), io::Error> {
+        self.io.get_mut().flush()
+    }
+}
+
 impl fmt::Debug for TcpStream {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.io.get_ref().fmt(f)

--- a/src/uds/stream.rs
+++ b/src/uds/stream.rs
@@ -248,6 +248,21 @@ impl TakeError for UnixStream {
     }
 }
 
+impl io::Read for UnixStream {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, io::Error> {
+        self.io.get_mut().read(buf)
+    }
+}
+
+impl io::Write for UnixStream {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, io::Error> {
+        self.io.get_mut().write(buf)
+    }
+    fn flush(&mut self) -> Result<(), io::Error> {
+        self.io.get_mut().flush()
+    }
+}
+
 impl fmt::Debug for UnixStream {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.io.get_ref().fmt(f)


### PR DESCRIPTION
There is no way to convert stream objects to their underlying type, but in some cases it's useful to be able to perform blocking I/O, such as when wrapped in stream that handles WouldBlock error in some way.

The specific use case for this is https://github.com/dbcfd/tls-async which works around the issue using `Compat<S>` where `S: AsyncRead + AsyncWrite`, which implements 0.1 Futures `Stream`. However this [won't work](https://github.com/rust-lang-nursery/futures-rs/issues/1463) outside of 0.1 executor (e.g. Tokio), which makes the usage with Romio awkward. I'm not sure what's the best solution here, but I would assume reexporting mio interfaces is acceptable. This would allow the depending library to use `Read + Write` directly.
