### PR TITLE
Maintenance notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 Asynchronous network primitives in Rust.
 
+__Note: This library is not actively being developed. If you're looking for an
+`async/await` compatible runtime consider using
+[`async-std`](https://github.com/async-rs/async-std).__
+
 Romio combines the powerful [`futures`][futures] abstractions with the
 nonblocking IO primitives of [`mio`][mio] to provide efficient and ergonomic
 asynchronous IO primitives for the Rust asynchronous networking ecosystem.


### PR DESCRIPTION
Adds a notice to the top of the repo that `romio` is not actively being developed, and points them to `async-std` instead. Thanks!